### PR TITLE
Fix: Ensure locale-independent percentage formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 .bsp
 out
 .bloop
+
+# idea
+.idea
+.idea_modules
+/.worksheet/

--- a/scautable/src/consoleFormat.scala
+++ b/scautable/src/consoleFormat.scala
@@ -34,8 +34,8 @@ object ConsoleFormat:
     inline def formatAsPercentage: String =
       if a == 0 then "0.00%"
       else
-        val a100 = BigDecimal(numA.toDouble(a) * 100).setScale(2, BigDecimal.RoundingMode.HALF_UP)
-        f"$a100%.2f%%"
+        val a100 = BigDecimal(numA.toDouble(a) * 100).setScale(2, BigDecimal.RoundingMode.HALF_UP).doubleValue
+        String.format(java.util.Locale.ROOT, "%.2f%%", a100)
   end extension
 
   extension [K <: Tuple, V <: Tuple](nt: Seq[NamedTuple[K, V]])


### PR DESCRIPTION
I tried to run the project locally and ran the `mill scautable.jvm.test`. During the test, one test that checks the `formatTypeTest` method failed. The reason:

```
Diff (- received, + expected)
 +-+---------------+-------+-------+-------+------+------+
-|0| int|100.00%| 0.00%| 0.00%|33.33%| 0.00%|
-|1| doubles|100.00%|100.00%|100.00%|33.33%| 0.00%|
-|2| long|100.00%| 0.00%|100.00%|33.33%| 0.00%|
+|0| int|100.00%| 0.00%| 0.00%|33.33%| 0.00%|
+|1| doubles|100.00%|100.00%|100.00%|33.33%| 0.00%|
+|2| long|100.00%| 0.00%|100.00%|33.33%| 0.00%|
 |3| recommendation| Int| Double| Long|String|String|
```

The test expected a number format with a period as a decimal separator (e.g. 100.00%), but instead received values with a comma (e.g. 100,00%).

The problem was in the `formatAsPercentage` method, which used the f-interpolator when formatting numbers:
`f"$a100%.2f%%`.

In some locales, the decimal separator is a comma (,) instead of a period (.), which could result in numbers being incorrectly formatted as 100.00% instead of 100.00%. This could cause errors or incorrect display of values on certain systems.
Read more: https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html

Currently, I've used `Locale.ROOT` for formatting, but potentially you will need to either rewrite the tests or adapt the output to the console to different Locale and take it as an argument.