### PR TITLE
Implement deduplicateHeaders macro

### DIFF
--- a/scautable/test/jvm/src/testCsv.scala
+++ b/scautable/test/jvm/src/testCsv.scala
@@ -391,6 +391,15 @@ import CsvSchema.*"""
 
   }
 
+  test("csv has duplicate headers") {
+    def csv: CsvIterator[("colA", "colA", "colA", "colB", "colC", "colA")] = CSV.absolutePath(Generated.resourceDir0 + "dups.csv")
+
+    // If the next two lines compile, this is a pretty good indicator that we've deduplicated the headers
+    def dedupCsv: CsvIterator[("colA", "colA_1", "colA_2", "colB", "colC", "colA_5")] = CSV.deduplicateHeaders(csv)
+    val testVal = dedupCsv.drop(1).next().colA_5
+    assert(testVal == "5")
+  }
+
   // test("url") {
   //   val csv = CSV.url("https://raw.githubusercontent.com/datasciencedojo/datasets/refs/heads/master/titanic.csv")
   // }

--- a/scautable/test/resources/dups.csv
+++ b/scautable/test/resources/dups.csv
@@ -1,0 +1,4 @@
+colA,colA,colA,colB,colC,colA
+1,1,1,2,3,1
+3,1,1,2,3,5
+5,1,1,2,3,1


### PR DESCRIPTION
Following the discussion at #42 and #43, this PR implements a header deduplication function using macros.

Pros:
- Cleaner implementation (less code and more readable)
- Warn the user and provide a possible solution
- Doesn't tamper with user data; leaves the action to the user

Cons:
- Use of a more complex reflection mechanism (FromExpr + underlying func)
- Have special use restrictions compared to type level programming (see the last example)
- Will provide a `report.info` even the user intention is to have duplicated headers

The logic is the same as in #44, and the sufix number will be based on the column's index. For example:
```scala
val csv: CsvIterator[("colA", "colB" "colA")] = CSV.absolutePath("...")
val uniqCsv: CsvIterator[("colA", "colB", "colA_2")] = CSV.deduplicateHeaders(csv)
```

One of the downsides of macros is their limited scope. For example, trying to use this macro with a function arg will raise a error:
```scala
@main def main =
  val csv = CSV.absolutePath("...")
  val csvWithoutDups = CSV.deduplicateHeaders(csv) // Compiles just fine

  def dedup[K <: Tuple](obj: CsvIterator[K]) = // Error: Expected a known value
    CSV.deduplicateHeaders(obj)

  // inlining any functions that uses macros internally would compile, too.
  // This is a leaky abstraction, though.
  // transparent inline def dedup[K <: Tuple](obj: CsvIterator[K]) =
  //   CSV.deduplicateHeaders(obj)
  // val csvWithoutDups = dedup(csv)
```