### PR TITLE
Case classes into macro definition

### DIFF
--- a/examples/prompts/viz.prompt.yml
+++ b/examples/prompts/viz.prompt.yml
@@ -19,7 +19,7 @@ messages:
 evaluators:
   - name: Output should use vegal lite v6
     string:
-      startsWith: |
+      contains: |
         ```json { "$schema": "https://vega.github.io/schema/vega-lite/v6.json"
 testData:
   - input: Gender

--- a/scautable/package.mill
+++ b/scautable/package.mill
@@ -16,7 +16,7 @@ object `package` extends RootModule {
   object jvm extends SharedModule with ScalaModule with build.PublishModule {
     override def ivyDeps= super.ivyDeps() ++ Agg(
       ivy"org.apache.poi:poi:5.4.1",
-      ivy"org.apache.poi:poi-ooxml:5.4.1",
+      ivy"org.apache.poi:poi-ooxml:5.4.1"
     )
   }
 

--- a/scautable/src/CsvOptions.scala
+++ b/scautable/src/CsvOptions.scala
@@ -1,0 +1,60 @@
+package io.github.quafadas.scautable
+
+import scala.quoted.*
+
+given FromExpr[TypeInferenceStrategy] with
+  def unapply(expr: Expr[TypeInferenceStrategy])(using
+      Quotes
+  ): Option[TypeInferenceStrategy] =
+    expr match
+      case '{ TypeInferenceStrategy.FirstRow } =>
+        Some(TypeInferenceStrategy.FirstRow)
+      case '{ TypeInferenceStrategy.AutoType } =>
+        Some(TypeInferenceStrategy.AutoType)
+      case '{ TypeInferenceStrategy.StringsOnly } =>
+        Some(TypeInferenceStrategy.StringsOnly)
+      case _ => None
+end given
+
+given ToExpr[TypeInferenceStrategy] with
+  def apply(ts: TypeInferenceStrategy)(using
+      Quotes
+  ): Expr[TypeInferenceStrategy] = ts match
+    case TypeInferenceStrategy.FirstRow => '{ TypeInferenceStrategy.FirstRow }
+    case TypeInferenceStrategy.AutoType => '{ TypeInferenceStrategy.AutoType }
+    case TypeInferenceStrategy.StringsOnly =>
+      '{ TypeInferenceStrategy.StringsOnly }
+end given
+
+enum TypeInferenceStrategy:
+  case FirstRow, AutoType, StringsOnly
+end TypeInferenceStrategy
+
+given ToExpr[CsvReadOptions] with
+  def apply(opt: CsvReadOptions)(using Quotes): Expr[CsvReadOptions] =
+    val delimiterExpr = Expr(opt.delimiter)
+    val typeInferenceStrategyExpr = Expr(opt.typeInferenceStrategy)
+    '{ CsvReadOptions($delimiterExpr, $typeInferenceStrategyExpr) }
+  end apply
+end given
+
+given FromExpr[CsvReadOptions] with
+  def unapply(expr: Expr[CsvReadOptions])(using
+      Quotes
+  ): Option[CsvReadOptions] =
+    import quotes.reflect.*
+    println("FromExpr unapply for CsvReadOptions called")
+    expr match
+      case '{ CsvReadOptions(${ Expr(d) }, ${ Expr(t) }) } =>
+        Some(CsvReadOptions(d, t))
+      case _ =>
+        println("match Failed for CsvReadOptions")
+        None
+    end match
+  end unapply
+end given
+
+case class CsvReadOptions(
+    delimiter: Char,
+    typeInferenceStrategy: TypeInferenceStrategy
+)

--- a/scautable/src/csvIterator.scala
+++ b/scautable/src/csvIterator.scala
@@ -29,12 +29,13 @@ import NamedTuple.*
   * ```
   * etc
   */
-class CsvIterator[K <: Tuple](filePath: String) extends Iterator[NamedTuple[K, StringyTuple[K & Tuple]]]:
+class CsvIterator[K <: Tuple](filePath: String, opts: CsvReadOptions) extends Iterator[NamedTuple[K, StringyTuple[K & Tuple]]]:
   type COLUMNS = K
-  
+
   type Col[N <: Int] = Tuple.Elem[K, N]
 
   def getFilePath: String = filePath
+  def getOpts: CsvReadOptions = opts
   lazy private val source = Source.fromFile(filePath)
   lazy private val lineIterator = source.getLines()
   lazy val headers = CSVParser.parseLine((Source.fromFile(filePath).getLines().next()))
@@ -88,7 +89,7 @@ import CsvSchema.*
   //   )
   // end numericTypeTest
 
-  inline def restart = new CsvIterator[K](filePath)    
+  inline def restart = new CsvIterator[K](filePath, opts)
   inline def copy = restart
 
   inline override def next() =

--- a/scautable/test/src-jvm/schema.scala
+++ b/scautable/test/src-jvm/schema.scala
@@ -1,14 +1,32 @@
-
 import io.github.quafadas.table.*
 import NamedTuple.*
+import scala.quoted.Quotes
 
+final val rd = CsvReadOptions2(
+  ';'
+)
 
 class CSVSchemaSuite extends munit.FunSuite:
-    test("Drop column by number") {
-        val csv: CsvIterator[("col1", "col2", "col3")] = CSV.resource("simple.csv")        
 
-        val drp = csv.dropColumn[csv.Col[1]]
+  test("Drop column by number") {
+    val csv: CsvIterator[("col1", "col2", "col3")] = CSV.resource("simple.csv")
 
-        println(csv.schemaGen)
-        
-    }
+    val drp = csv.dropColumn[csv.Col[1]]
+
+    println(csv.schemaGen)
+
+  }
+
+  test("Drop column by number") {
+
+    val csv: CsvIterator[("col1", "col2", "col3")] = CSV.resource(
+      "simple.csv",
+      CsvReadOptions2(
+        ';'
+      )
+    )
+
+    println(csv.schemaGen)
+
+  }
+end CSVSchemaSuite

--- a/scautable/test/src-jvm/schema.scala
+++ b/scautable/test/src-jvm/schema.scala
@@ -1,10 +1,9 @@
+package io.github.quafadas.scautable
+
 import io.github.quafadas.table.*
 import NamedTuple.*
 import scala.quoted.Quotes
-
-final val rd = CsvReadOptions2(
-  ';'
-)
+import java.awt.Window.Type
 
 class CSVSchemaSuite extends munit.FunSuite:
 
@@ -19,14 +18,19 @@ class CSVSchemaSuite extends munit.FunSuite:
 
   test("Drop column by number") {
 
+    val csv2 = CSV.resource("simple.csv", CsvReadOptions(';', TypeInferenceStrategy.StringsOnly))
+
+    println(csv2.getOpts)
+
     val csv: CsvIterator[("col1", "col2", "col3")] = CSV.resource(
       "simple.csv",
-      CsvReadOptions2(
-        ';'
+      CsvReadOptions(
+        ',',
+        TypeInferenceStrategy.AutoType
       )
     )
 
-    println(csv.schemaGen)
+    println(csv.getOpts)
 
   }
 end CSVSchemaSuite


### PR DESCRIPTION
@Kvintochka  @Dorodri  

Hi guys, 

A bit embarrassed I didn't figure this out sooner, but it _is_ in fact possible to get reasonably complex types into the macro which reads the CSV file. If you have a look at the CSVOptions file here, it makes its way through the configuration and into the `CsvIterator` that does the heavy lifting of actually working through the data.

I think this means we actually can have some quite rich configuration, and it relaxes many of the design constraints I was concerned about. 

Hopefully, we could use this, or a similar concept as a template for some of the things which require user facing configuration :-)

I think the tests still pass, and the new test successfully propagates the case class through the macro. 